### PR TITLE
test: regression test for price-cross limit (fix already on main)

### DIFF
--- a/test/orderbook_test.cpp
+++ b/test/orderbook_test.cpp
@@ -755,6 +755,27 @@ TEST_F(LimitOrderTest, TestFoK_MarketBuy_CannotFill) {
     n.Verify({"CreateOrder Accepted 811 11 11"});
 }
 
+TEST_F(LimitOrderTest, TestLimitOrder_SellDoesNotCrossPriceLimit) {
+    // Rest two bids at different prices.
+    processLine(ob, "1	L	B	2	9296	N");
+    processLine(ob, "2	L	B	2	9274	N");
+    n.Reset();
+
+    // Sell limit priced BETWEEN the two bids. It should fully clear the 9296
+    // bid (qty 2) and leave its remaining qty (1) resting, WITHOUT trading
+    // through to the 9274 bid which is below the limit price.
+    processLine(ob, "3	L	S	3	9286	N");
+
+    // Only one trade, against the 9296 bid. The 9274 bid must NOT trade.
+    // clang-format off
+    n.Verify({"CreateOrder Accepted 3 3 3",
+              "1 3 FilledComplete FilledPartial 2 9296"});
+    // clang-format on
+
+    // The 9274 bid must remain resting with its full quantity.
+    ASSERT_TRUE(ob->hasOrder(2));
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Context
While auditing `cpp-orderbook` for the price-cross matching bug fixed in the Go engine (geseq/orderbook#25), I found the same class of bug in `PriceLevel::processLimitOrder` — the cross-price predicate was checked only at the entry guard, so a marketable limit/IOC order could fill resting levels beyond its limit price.

**However, `main` already contains the production fix** (the in-loop predicate in `src/pricelevel.cpp`, added independently in recent commits). So this branch carries **no production change** — rebased onto latest `main`, the net diff is the regression test only.

## What this adds
`TestLimitOrder_SellDoesNotCrossPriceLimit`: rests bids at 9296 and 9274, sends a sell limit at 9286 with quantity to overflow the top level, and asserts only the 9296 bid trades while the 9274 bid stays resting. Locks in the behavior so the bug can't regress (there was previously no test covering a limit order with book levels beyond the taker's price).

Rebased onto `main` (`be0ae6b`); full suite 7/7 targets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)