### PR TITLE
ci: run realistic + matching-engine benchmarks on PRs

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -1,8 +1,11 @@
 name: "Benchmark PR"
 
-# Builds the throughput benchmark for the PR branch and for main, then posts a
-# side-by-side comparison comment. Throughput on hosted runners is noisy and not
-# performance-calibrated, so the numbers are informational only.
+# On each PR, runs BOTH benchmarks for the PR branch and for main and posts a
+# single combined comment:
+#   1. Realistic deep-book throughput (main.cpp, depth W=50000).
+#   2. The matching-engine-benchmark harness (perf mode, 5 scenarios).
+# Throughput on hosted runners is noisy and not performance-calibrated, so the
+# numbers are informational only; the harness correctness status is meaningful.
 
 on:
   pull_request:
@@ -13,13 +16,12 @@ permissions:
   pull-requests: write
 
 env:
-  # Centralise CPM downloads so the PR and base builds share one cache and Boost
-  # is fetched once instead of twice.
-  CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm-cache
+  BENCH_SHA: "77697a115e76a25a1e2aa886f555d55b87fcf052"
+  BENCH_URL: "https://github.com/flash1-dev/matching-engine-benchmark"
 
 jobs:
   benchmark:
-    name: Throughput comparison
+    name: Dual benchmark comparison
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -28,55 +30,193 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache CPM sources
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.cpm-cache
-          key: cpm-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'cmake/CPM.cmake', 'package-lock.cmake') }}
-          restore-keys: |
-            cpm-${{ runner.os }}-
-
-      - name: Install locale
+      - name: Install dependencies
         run: |
-          # Boost comes from CPM, not the system: installing libboost-all-dev
-          # makes find_package use system Boost, whose Boost::intrusive target
-          # is gone under CMake's CMP0167. main.cpp also imbues
-          # std::locale("en_US.UTF-8"), which throws if the locale is absent.
+          # locales: main.cpp imbues std::locale("en_US.UTF-8"), which throws if
+          # the locale is absent. g++-14/cmake/libboost-all-dev are for the
+          # HARNESS only. The engine/adapter builds get Boost from CPM; system
+          # Boost must not leak into them (CMP0167 drops Boost::intrusive), so we
+          # never pass it to the `main` or adapter builds.
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends locales
+          sudo apt-get install -y --no-install-recommends \
+            locales g++-14 cmake libboost-all-dev
           sudo locale-gen en_US.UTF-8
 
-      - name: Build PR (Release)
+      - name: Clone benchmark harness at pinned SHA
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          git clone "$BENCH_URL" bench-harness
+          git -C bench-harness checkout "$BENCH_SHA"
+
+      - name: Build benchmark harness
+        run: |
+          cmake -S bench-harness -B bench-harness/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-14 \
+            -DCMAKE_CXX_COMPILER=g++-14
+          cmake --build bench-harness/build -j
+
+      # ---- PR branch ---------------------------------------------------------
+      - name: Build PR realistic bench (Release)
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
           cmake --build build -j --target main
 
-      - name: Run PR benchmark
+      - name: Run PR realistic bench
         run: |
           mkdir -p benchmarks
-          ./build/main -n throughput -duration 10 -seed 42 > benchmarks/pr.txt 2>&1
+          ./build/main -n throughput -duration 10 -depth 50000 -seed 42 \
+            > benchmarks/pr-realistic.txt 2>&1
 
-      - name: Build base (main, Release)
+      - name: Build PR adapter
+        run: |
+          BENCH_SRC="$PWD/bench-harness" ME_ENGINE_SRC="$PWD" bash bench/build.sh
+          ls -l bench/cpp_orderbook_adapter.so
+
+      - name: Run PR harness scenarios (perf)
+        working-directory: bench-harness
+        run: |
+          for scenario in static normal swing-25 swing-40 flash-crash; do
+            echo "::group::pr $scenario"
+            ./harness \
+              --engine "$GITHUB_WORKSPACE/bench/cpp_orderbook_adapter.so" \
+              --scenario "$scenario" \
+              --mode perf \
+              --matcher-core 2 \
+              --drainer-core 3 || true
+            echo "::endgroup::"
+          done
+          mkdir -p "$GITHUB_WORKSPACE/benchmarks/pr-harness"
+          if ls results/*.json >/dev/null 2>&1; then
+            mv results/*.json "$GITHUB_WORKSPACE/benchmarks/pr-harness/"
+          fi
+
+      # ---- base (main) -------------------------------------------------------
+      - name: Build base realistic bench (Release)
         run: |
           git worktree add ../base main
-          cmake -S ../base -B ../base/build -DCMAKE_BUILD_TYPE=Release
+          cmake -S ../base -B ../base/build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
           cmake --build ../base/build -j --target main
 
-      - name: Run base benchmark
+      - name: Run base realistic bench
         run: |
-          ../base/build/main -n throughput -duration 10 -seed 42 > benchmarks/base.txt 2>&1
+          ../base/build/main -n throughput -duration 10 -depth 50000 -seed 42 \
+            > benchmarks/base-realistic.txt 2>&1
 
-      - name: Build comparison
+      - name: Build base adapter
         run: |
-          {
-            echo "### This PR"
-            echo
-            cat benchmarks/pr.txt
-            echo
-            echo "### main (base)"
-            echo
-            cat benchmarks/base.txt
-          } > benchmarks/comparison.txt
+          BENCH_SRC="$PWD/bench-harness" ME_ENGINE_SRC="$PWD/../base" bash ../base/bench/build.sh
+          ls -l ../base/bench/cpp_orderbook_adapter.so
+
+      - name: Run base harness scenarios (perf)
+        working-directory: bench-harness
+        run: |
+          for scenario in static normal swing-25 swing-40 flash-crash; do
+            echo "::group::base $scenario"
+            ./harness \
+              --engine "$GITHUB_WORKSPACE/../base/bench/cpp_orderbook_adapter.so" \
+              --scenario "$scenario" \
+              --mode perf \
+              --matcher-core 2 \
+              --drainer-core 3 || true
+            echo "::endgroup::"
+          done
+          mkdir -p "$GITHUB_WORKSPACE/benchmarks/base-harness"
+          if ls results/*.json >/dev/null 2>&1; then
+            mv results/*.json "$GITHUB_WORKSPACE/benchmarks/base-harness/"
+          fi
+
+      # ---- report ------------------------------------------------------------
+      - name: Build combined report
+        run: |
+          python3 - <<'PY'
+          import glob, json, os, re
+
+          SCENARIOS = ["static", "normal", "swing-25", "swing-40", "flash-crash"]
+
+          def ops(path):
+              try:
+                  txt = open(path).read()
+              except OSError:
+                  return None
+              m = re.search(r"Throughput:\s*([\d,\.]+)\s*ops/sec", txt)
+              return float(m.group(1).replace(",", "")) if m else None
+
+          def load(dir_):
+              out = {}
+              for path in sorted(glob.glob(os.path.join(dir_, "*.json"))):
+                  try:
+                      data = json.load(open(path))
+                  except (OSError, ValueError):
+                      continue
+                  scen = data.get("scenario")
+                  if scen is None:
+                      base = os.path.basename(path)
+                      scen = next((s for s in SCENARIOS if f"_{s}_" in base), None)
+                  if scen:
+                      out[scen] = data
+              return out
+
+          def throughput(d):
+              v = (d or {}).get("throughput_msgs_per_s")
+              try:
+                  return float(v)
+              except (TypeError, ValueError):
+                  return None
+
+          def correctness(d):
+              return (d or {}).get("correctness", {}).get("status", "MISSING")
+
+          def pct(pr, base):
+              if pr is None or base is None or base == 0:
+                  return "n/a"
+              return f"{(pr / base - 1) * 100:+.1f}%"
+
+          def fmt_ops(v):
+              return f"{v:,.0f}" if v is not None else "n/a"
+
+          def fmt_m(v):
+              return f"{v / 1e6:.3f}" if v is not None else "n/a"
+
+          pr_ops = ops("benchmarks/pr-realistic.txt")
+          base_ops = ops("benchmarks/base-realistic.txt")
+          pr_h = load("benchmarks/pr-harness")
+          base_h = load("benchmarks/base-harness")
+
+          lines = []
+          lines.append("<!-- benchmark-pr -->")
+          lines.append("## Benchmark PR")
+          lines.append("")
+          lines.append("_Throughput on hosted runners is noisy and not "
+                       "performance-calibrated; treat the numbers as "
+                       "informational only._")
+          lines.append("")
+          lines.append("### Realistic deep-book throughput (W=50000)")
+          lines.append("")
+          lines.append("| Metric | PR | main | change |")
+          lines.append("|---|---|---|---|")
+          lines.append(f"| ops/sec | {fmt_ops(pr_ops)} | {fmt_ops(base_ops)} | "
+                       f"{pct(pr_ops, base_ops)} |")
+          lines.append("")
+          lines.append("### Matching-engine-benchmark (perf mode)")
+          lines.append("")
+          lines.append(f"Harness pinned at `{os.environ.get('BENCH_SHA', '?')}`.")
+          lines.append("")
+          lines.append("| Scenario | PR (M msgs/s) | main (M msgs/s) | change | "
+                       "PR correctness |")
+          lines.append("|---|---|---|---|---|")
+          for scen in SCENARIOS:
+              p, b = pr_h.get(scen), base_h.get(scen)
+              pt, bt = throughput(p), throughput(b)
+              lines.append(f"| {scen} | {fmt_m(pt)} | {fmt_m(bt)} | "
+                           f"{pct(pt, bt)} | {correctness(p)} |")
+
+          body = "\n".join(lines) + "\n"
+          with open("benchmarks/report.md", "w") as fh:
+              fh.write(body)
+          print(body)
+          PY
 
       - name: Comment PR
         uses: actions/github-script@v6
@@ -84,11 +224,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const results = fs.readFileSync('benchmarks/comparison.txt', 'utf8');
+            const body = fs.readFileSync('benchmarks/report.md', 'utf8');
             const marker = '<!-- benchmark-pr -->';
-            const body = marker + '\n## Throughput Benchmark\n\n'
-              + '_Throughput on hosted runners is noisy and not performance-calibrated; treat as informational only._\n\n'
-              + '```\n' + results + '\n```';
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <chrono>
+#include <deque>
 #include <iomanip>
 #include <iostream>
 #include <locale>
@@ -60,40 +61,42 @@ void latency(int64_t seed, int duration, int pd, orderbook::Decimal lowerBound, 
     // Implement the latency benchmark logic.
 }
 
-void throughput(int64_t seed, int duration, orderbook::Decimal lowerBound, orderbook::Decimal upperBound, orderbook::Decimal minSpread) {
+void throughput(int64_t seed, int duration, int depth, orderbook::Decimal lowerBound, orderbook::Decimal upperBound, orderbook::Decimal minSpread) {
     std::cout << "starting throughput benchmark...\n";
-    // Implement the throughput benchmark logic.
+    // Deep-book throughput: maintain a sliding window of `depth` live resting
+    // orders with monotonically climbing ids. Each iteration adds one order and,
+    // once the book is full, cancels the oldest still-live id — so the book stays
+    // ~depth deep and we measure the add/cancel/index/pool path at realistic
+    // depth. All orders rest on the bid side (no asks) so nothing ever crosses.
     auto n = orderbook::EmptyNotification();
     auto ob = std::make_unique<orderbook::OrderBook<orderbook::EmptyNotification>>(n);
-    orderbook::Decimal bid, ask, bidQty, askQty;
-    std::tie(bid, ask, bidQty, askQty) = getInitialVars(lowerBound, upperBound, minSpread);
 
-    uint64_t nextID = 0, buyID = 0, sellID = 0, operations = 0;
+    orderbook::Decimal qty(10, 0);
+    // Spread prices across the band on a minSpread tick grid.
+    int64_t ticks = ((upperBound - lowerBound) / minSpread).to_int();
+    if (ticks < 1) ticks = 1;
+
+    uint64_t nextID = 0, operations = 0;
+    std::deque<OrderID> live;  // ids of resting orders, oldest at front.
 
     auto end = std::chrono::steady_clock::now() + std::chrono::seconds(duration);
     std::default_random_engine generator(seed);
-    std::uniform_int_distribution<int> distribution(0, 9);
+    std::uniform_int_distribution<int64_t> distribution(0, ticks - 1);
 
     auto start = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() < end) {
-        int r = distribution(generator);
-        bool decrease = r < 5;
+        orderbook::Decimal price = lowerBound + minSpread * orderbook::Decimal(distribution(generator), 0);
 
-        std::tie(bid, ask) = getPrice(bid, ask, minSpread, decrease);
-        if (bid < lowerBound) {
-            std::tie(bid, ask) = getPrice(bid, ask, minSpread, false);
-        } else if (ask > upperBound) {
-            std::tie(bid, ask) = getPrice(bid, ask, minSpread, true);
+        OrderID id = ++nextID;
+        ob->addOrder(id, Type::Limit, Side::Buy, qty, price, Flag::None);
+        live.push_back(id);
+        operations += 1;
+
+        if (live.size() > static_cast<size_t>(depth)) {
+            ob->cancelOrder(live.front());
+            live.pop_front();
+            operations += 1;
         }
-
-        ob->cancelOrder(buyID);
-        ob->cancelOrder(sellID);
-        buyID = ++nextID;
-        sellID = ++nextID;
-        ob->addOrder(buyID, Type::Limit, Side::Buy, bidQty, bid, Flag::None);
-        ob->addOrder(sellID, Type::Limit, Side::Sell, askQty, ask, Flag::None);
-
-        operations += 4;  // 2 cancels + 2 adds
     }
 
     auto finish = std::chrono::steady_clock::now();
@@ -108,7 +111,7 @@ void throughput(int64_t seed, int duration, orderbook::Decimal lowerBound, order
     std::cout << "Avg latency: " << nanosecPerOp << " ns/op" << std::endl;
 }
 
-void run(int64_t seed, int duration, int pd, const std::string &lb, const std::string &ub, const std::string &ms, const std::string &n, bool sched) {
+void run(int64_t seed, int duration, int pd, int depth, const std::string &lb, const std::string &ub, const std::string &ms, const std::string &n, bool sched) {
     orderbook::Decimal lowerBound(lb);
     orderbook::Decimal upperBound(ub);
     orderbook::Decimal minSpread(ms);
@@ -116,7 +119,7 @@ void run(int64_t seed, int duration, int pd, const std::string &lb, const std::s
     if (n == "latency") {
         latency(seed, duration, pd, lowerBound, upperBound, minSpread, sched);
     } else if (n == "throughput") {
-        throughput(seed, duration, lowerBound, upperBound, minSpread);
+        throughput(seed, duration, depth, lowerBound, upperBound, minSpread);
     }
 }
 
@@ -127,11 +130,12 @@ int main(int argc, char *argv[]) {
     std::string ub = getCmdOption(argv, argv + argc, "-u", "100.0");
     std::string ms = getCmdOption(argv, argv + argc, "-m", "0.25");
     int pd = std::stoi(getCmdOption(argv, argv + argc, "-p", "10"));
+    int depth = std::stoi(getCmdOption(argv, argv + argc, "-depth", "50000"));
     bool sched = cmdOptionExists(argv, argv + argc, "-sched");
     std::string n = getCmdOption(argv, argv + argc, "-n", "latency");
 
     std::cout << "PID: " << getpid() << std::endl;
-    run(seed, duration, pd, lb, ub, ms, n, sched);
+    run(seed, duration, pd, depth, lb, ub, ms, n, sched);
     return 0;
 }
 


### PR DESCRIPTION
Replaces the degenerate `main.cpp` cancel+add bench (only ~2 live orders) with a **realistic deep-book** sliding-window bench (`-depth`, default 50k live), and makes the PR workflow run **both** benchmarks PR-vs-main:

- **Realistic deep-book throughput** (`main -n throughput -depth 50000`).
- **Matching-engine-benchmark** (the 5 scenarios, perf mode) with the consensus-hash correctness column.

Both results are posted in a single upserted PR comment. This PR has no engine change, so its own run should show ~no difference (it's the smoke test); the real signal shows once it's merged and engine PRs rebase on it.