### PR TITLE
ci: ASan/UBSan/TSan gates on the benchmark corpus

### DIFF
--- a/.github/tsan-suppressions.txt
+++ b/.github/tsan-suppressions.txt
@@ -1,0 +1,11 @@
+# ThreadSanitizer suppressions — HARNESS / BOOST INTERNALS ONLY.
+#
+# The benchmark harness moves reports between its matcher and drainer threads
+# over a boost::lockfree::spsc_queue (src/transport.cpp). That lock-free queue
+# uses relaxed/acquire-release atomics that TSan cannot always prove correct,
+# producing benign data-race reports inside boost::lockfree. These are NOT in
+# our engine/adapter code, so suppress only the boost::lockfree namespace.
+#
+# Do NOT add suppressions for cpp-orderbook engine or adapter symbols — we want
+# real races in our report-push path to FAIL the job.
+race:boost::lockfree

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,109 @@
+# Sanitizers
+#
+# Runs the matching-engine-benchmark corpus (5 scenarios) under ASan, UBSan and
+# TSan as SEPARATE matrix stages. The gate here is "no sanitizer report" — the
+# correctness consensus-hash is gated by benchmark-comparison.yml, not here, so
+# we run a reduced --count under instrumentation to keep runtime sane.
+#
+#   Benchmark harness : https://github.com/flash1-dev/matching-engine-benchmark
+#   Pinned SHA        : 77697a115e76a25a1e2aa886f555d55b87fcf052
+#   License           : MIT
+name: "Sanitizers"
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  BENCH_SHA: "77697a115e76a25a1e2aa886f555d55b87fcf052"
+  BENCH_URL: "https://github.com/flash1-dev/matching-engine-benchmark"
+  SAN_COUNT: "200000"
+
+jobs:
+  sanitize:
+    name: "Sanitizer (${{ matrix.sanitizer }})"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, thread]
+    steps:
+      - name: Checkout cpp-orderbook
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            g++-14 gcc-14 cmake libboost-all-dev \
+            libasan8 libubsan1 libtsan2
+
+      - name: Clone benchmark harness at pinned SHA
+        run: |
+          git clone "$BENCH_URL" bench-harness
+          git -C bench-harness checkout "$BENCH_SHA"
+
+      - name: Build benchmark harness (instrumented)
+        run: |
+          cmake -S bench-harness -B bench-harness/build \
+            -DCMAKE_C_COMPILER=gcc-14 \
+            -DCMAKE_CXX_COMPILER=g++-14 \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_FLAGS="-fsanitize=${{ matrix.sanitizer }} -fno-omit-frame-pointer -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=${{ matrix.sanitizer }}"
+          cmake --build bench-harness/build -j
+
+      - name: Build cpp-orderbook adapter (instrumented)
+        run: |
+          ME_EXTRA_CXXFLAGS="-fsanitize=${{ matrix.sanitizer }} -fno-omit-frame-pointer -g" \
+          BENCH_SRC="$PWD/bench-harness" \
+          ME_ENGINE_SRC="$PWD" \
+          bash bench/build.sh
+          ls -l bench/cpp_orderbook_adapter.so
+
+      - name: Run corpus under sanitizer
+        working-directory: bench-harness
+        env:
+          ASAN_OPTIONS: "halt_on_error=1:abort_on_error=1:detect_leaks=1"
+          UBSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_stacktrace=1"
+          TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:suppressions=${{ github.workspace }}/.github/tsan-suppressions.txt"
+        run: |
+          fail=0
+          for scenario in static normal swing-25 swing-40 flash-crash; do
+            echo "::group::${{ matrix.sanitizer }} $scenario"
+            log="san_${scenario}.log"
+            # The harness legitimately exits non-zero on the runner (audit
+            # skipped, reduced --count so the consensus hash != the count=1e6
+            # reference, core-pinning), which is NOT a sanitizer finding. So we
+            # ignore its exit code (`|| true`) and gate ONLY on sanitizer
+            # output: the sanitizers run with abort_on_error/halt_on_error, so a
+            # real finding prints one of the patterns below.
+            ./harness \
+                --engine "$GITHUB_WORKSPACE/bench/cpp_orderbook_adapter.so" \
+                --scenario "$scenario" \
+                --mode perf \
+                --count "$SAN_COUNT" \
+                --matcher-core 2 \
+                --drainer-core 3 2>&1 | tee "$log" || true
+            if grep -Eq "ERROR: AddressSanitizer|ERROR: LeakSanitizer|runtime error:|WARNING: ThreadSanitizer|SUMMARY: .*Sanitizer" "$log"; then
+              echo "::error::${{ matrix.sanitizer }} sanitizer report in $scenario"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "Sanitizer gate FAILED for ${{ matrix.sanitizer }}."
+            exit 1
+          fi
+          echo "Sanitizer gate passed for ${{ matrix.sanitizer }}: no findings."
+
+      - name: Upload sanitizer logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitizer-logs-${{ matrix.sanitizer }}
+          path: bench-harness/san_*.log

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -14,6 +14,9 @@
 # Overrides:
 #   BENCH_SRC=/path/to/existing/matching-engine-benchmark   (skip the clone)
 #   ME_ENGINE_SRC=/path/to/cpp-orderbook                    (default: this repo)
+#   ME_EXTRA_CXXFLAGS="..."  extra flags appended to the adapter g++ command
+#                            (default empty => identical behavior). Used by the
+#                            sanitizer CI to inject e.g. -fsanitize=address.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -110,6 +113,7 @@ g++ -std=c++20 -O3 -march=native -fPIC -shared \
     "$ENGINE/src/order.cpp" \
     "$ENGINE/src/types.cpp" \
     -pthread \
+    ${ME_EXTRA_CXXFLAGS:-} \
     -o "$OUT"
 
 echo "built: $OUT"


### PR DESCRIPTION
Adds three sanitizer stages (matrix: address / undefined / thread) that build the matching-engine-benchmark harness + the cpp adapter instrumented and run the 5-scenario corpus under each sanitizer, failing on any report.

- ASan/UBSan catch memory/UB bugs in the engine on the real workload.
- TSan validates the adapter's cross-thread report pushing (the harness drives matcher+drainer threads over the SPSC queue; the engine itself is single-threaded). A minimal `race:boost::lockfree` suppression covers the harness's lock-free transport internals only — no engine/adapter symbols are suppressed.
- `bench/build.sh` gains an `ME_EXTRA_CXXFLAGS` hook (default empty → unchanged) so the workflow can inject `-fsanitize=…`.

Reduced `--count` keeps each instrumented run reasonable; correctness-hash is gated elsewhere, the gate here is "no sanitizer finding".