### PR TITLE
perf(bench): custom SPSC report transport (cpp-fastchan) — competition bench +22–32%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,15 @@ set(Boost_USE_STATIC_RUNTIME OFF)
 CPMAddPackage( NAME Boost VERSION 1.80.0 GITHUB_REPOSITORY "boostorg/boost" GIT_TAG "boost-1.80.0")
 CPMAddPackage( NAME decimal VERSION 2.1.0 GITHUB_REPOSITORY "geseq/cpp-decimal" GIT_TAG "v2.1.0")
 CPMAddPackage( NAME pool VERSION 0.6.1 GITHUB_REPOSITORY "geseq/cpp-pool" GIT_TAG "v0.5.0")
+# cpp-fastchan defaults its own ENABLE_TESTING=ON and shares that option name
+# with us, so add_subdirectory'ing it would pull its (slow) test suite into our
+# ctest. Force ENABLE_TESTING OFF just for fastchan's configure, then restore our
+# value for our own test block below. (We use add_subdirectory, not DOWNLOAD_ONLY,
+# so _deps/fastchan-src/include is populated for the bench adapter build.)
+set(_ob_enable_testing_save "${ENABLE_TESTING}")
+set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+CPMAddPackage( NAME fastchan GITHUB_REPOSITORY "geseq/cpp-fastchan" GIT_TAG "main")
+set(ENABLE_TESTING "${_ob_enable_testing_save}" CACHE BOOL "" FORCE)
 
 include_directories(decimal_SOURCE_DIR)
 include_directories(pool_SOURCE_DIR)

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -78,6 +78,8 @@ fi
 
 DECIMAL_INC="$BUILD_DIR/_deps/decimal-src/include"
 POOL_INC="$BUILD_DIR/_deps/pool-src/include"
+# geseq/cpp-fastchan: header-only SPSC channel backing engine_get_transport().
+FASTCHAN_INC="$BUILD_DIR/_deps/fastchan-src/include"
 # Boost from CPM is laid out as a super-project; its component headers live in
 # libs/<lib>/include. Collect every include dir so <boost/...> resolves.
 BOOST_SRC="$BUILD_DIR/_deps/boost-src"
@@ -90,7 +92,7 @@ fi
 # Fallback: a flattened boost include root, if present.
 [ -d "$BOOST_SRC/include" ] && BOOST_INCS+=("-I$BOOST_SRC/include")
 
-for p in "$DECIMAL_INC" "$POOL_INC"; do
+for p in "$DECIMAL_INC" "$POOL_INC" "$FASTCHAN_INC"; do
     if [ ! -d "$p" ]; then
         echo "error: dependency include dir missing: $p" >&2
         echo "       (CMake configure of $ENGINE did not populate _deps)" >&2
@@ -116,6 +118,7 @@ g++ -std=c++20 -O3 -march=native $LTO_FLAG -fPIC -shared \
     -I"$ENGINE/src" \
     -I"$DECIMAL_INC" \
     -I"$POOL_INC" \
+    -I"$FASTCHAN_INC" \
     "${BOOST_INCS[@]}" \
     "$DIR/cpp_orderbook_adapter.cpp" \
     "$ENGINE/src/pricelevel.cpp" \

--- a/bench/cpp_orderbook_adapter.cpp
+++ b/bench/cpp_orderbook_adapter.cpp
@@ -41,12 +41,18 @@
 // (O(1), pre-sized once, single cold growth branch), and the hot handlers are
 // always-inlined.
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "matching_engine_api.h"
 #include "orderbook.hpp"
 #include "types.hpp"
+
+// Report transport backend: geseq/cpp-fastchan.
+#include "spsc.hpp"
 
 using orderbook::Decimal;
 using orderbook::ExecType;
@@ -353,6 +359,65 @@ HOT_INLINE void onModify(const modify_t* m) {
     e->alive = (residual > 0);
 }
 
+// ---------------------------------------------------------------------------
+// Single-producer / single-consumer report channel (geseq/cpp-fastchan).
+//
+// The report stream is carried by fastchan::SPSC<me_report_t, ...>, the
+// project owner's vetted header-only SPSC channel. me_report_t is a 64-byte
+// trivially-copyable POD, which is exactly what the channel's slot array
+// (std::array<T, N>) and value-copy put()/get() want.
+//
+// Modes: NonBlocking put + NonBlocking get.
+//   - put(value)        -> bool: false when full. tx_push maps that to 0 so
+//                          emit()'s pause-spin retries (matching the harness
+//                          "0 = full" push contract).
+//   - get()             -> std::optional<me_report_t>: nullopt when empty.
+//
+// Capacity is a COMPILE-TIME template parameter in cpp-fastchan (rounded up to
+// the next power of two), so the runtime `capacity` create() argument cannot be
+// honoured directly. kChanSize is fixed to a generous 1<<20 slots — the same
+// headroom the previous ring used. In perf mode a dedicated drainer thread runs
+// concurrently, so even if the harness requested a larger capacity the producer
+// only pause-spins briefly when momentarily full; it never deadlocks.
+//
+// FIFO + flush-publishes-tail: cpp-fastchan's put() does a release-store of the
+// producer index on EVERY call (it does not buffer a partial batch), so each
+// report is visible to the consumer as soon as it is enqueued and ordering is
+// strict FIFO. The tail is therefore always already published, and tx_flush()
+// is a no-op.
+// ---------------------------------------------------------------------------
+
+constexpr std::size_t kChanSize = std::size_t(1) << 20;  // compile-time capacity
+
+using ReportChan = fastchan::SPSC<me_report_t, kChanSize, fastchan::YieldWaitStrategy, fastchan::YieldWaitStrategy,
+                                  fastchan::ReturnMode::NonBlocking, fastchan::ReturnMode::NonBlocking>;
+
+void* tx_create(uint32_t /*capacity*/) { return new ReportChan(); }
+
+int tx_push(void* handle, const me_report_t* report) {
+    return static_cast<ReportChan*>(handle)->put(*report) ? 1 : 0;
+}
+
+uint32_t tx_drain(void* handle, me_report_t* out, uint32_t max) {
+    ReportChan* c = static_cast<ReportChan*>(handle);
+    uint32_t n = 0;
+    while (n < max) {
+        std::optional<me_report_t> v = c->get();
+        if (!v) [[unlikely]] {
+            break;
+        }
+        out[n++] = *v;
+    }
+    return n;
+}
+
+void tx_flush(void* /*handle*/) {
+    // cpp-fastchan's put() release-stores the producer index on every call, so
+    // the tail is already visible to the consumer — nothing to publish.
+}
+
+void tx_destroy(void* handle) { delete static_cast<ReportChan*>(handle); }
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -438,6 +503,11 @@ uint64_t engine_query_depth_at(int64_t price_ticks, uint8_t side) {
         }
     }
     return total;
+}
+
+const me_transport_t* engine_get_transport(void) {
+    static const me_transport_t T = {tx_create, tx_push, tx_drain, tx_flush, tx_destroy};
+    return &T;
 }
 
 void engine_on_batch(const me_msg_t* msgs, uint32_t n) {


### PR DESCRIPTION
Backs the matching-engine-benchmark report queue with **`geseq/cpp-fastchan`** instead of the harness's default `boost::lockfree::spsc_queue`, via the API's `engine_get_transport()` escape hatch. **Adapter-only — the engine is untouched.**

## Why
The competition harness is **transport-bound**: the engine (single-thread replay) runs ~28–37 M msgs/s, but the end-to-end harness caps at ~14 because every report crosses a SP/SC queue to the drainer thread, and the default `boost::lockfree::spsc_queue` does a release-store per push. Profiling + an assert-on/off A/B confirmed the queue, not the book, is the limiter. The harness API explicitly permits an engine to substitute its own transport ("e.g. a proprietary lock-free ring").

## What
- `bench/cpp_orderbook_adapter.cpp`: export `engine_get_transport()` backed by `fastchan::SPSC<me_report_t, 1<<20>` (create/push/drain/flush/destroy).
- `CMakeLists.txt`: CPM dep `geseq/cpp-fastchan`, bracketed with an `ENABLE_TESTING` save/restore so fastchan's own (shared-named) test suite doesn't join our `ctest`.
- `bench/build.sh`: fastchan include path.

## Results — 5-way SPSC bake-off (same engine, same-run best-of-12)
| scenario | boost (default) | **cpp-fastchan** | moodycamel | rigtorp | hand-rolled |
|---|---|---|---|---|---|
| static | 14.2 | **18.3** | 12.4 | 13.7 | 17.0 |
| normal | 14.0 | **18.5** | 13.3 | 13.4 | 17.1 |
| swing-25 | 13.7 | **17.6** | 13.6 | 13.4 | 17.4 |
| swing-40 | 14.4 | **17.6** | 12.3 | 12.7 | 14.2 |
| flash-crash | 13.9 | **17.0** | 13.6 | 13.0 | 16.7 |

**cpp-fastchan wins outright: +22–32% over the boost default** across all 5 scenarios (M msgs/s), beating moodycamel, rigtorp, and a hand-rolled batched ring. This is the lever that actually moves the *competition* number — the engine optimizations (already merged) were transport-capped.

## Correctness
Byte-identical consensus hash **PASS on all 5 scenarios** (boost default and cpp-fastchan produce identical trade streams). Verified from a clean from-scratch build. `ctest` unaffected (fastchan's own tests excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0196EKKWudtsg3gButufhDxz